### PR TITLE
Add support for CP312 & CP313

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires = [
     "cython>=0.29.24",
 
     # manual sync numpy version with requirements/runtime.txt
-    "numpy>=1.26.2,<2  ; python_version < '4.0'  and python_version >= '3.11'",  # Python 3.11+ 
+    "numpy>=2.1.0      ; python_version < '4.0'  and python_version >= '3.13'",  # Python 3.13+
+    "numpy>=1.26.2,<2  ; python_version < '3.13' and python_version >= '3.11'",  # Python 3.11+ 
     "numpy>=1.26.2,<2  ; python_version < '3.11' and python_version >= '3.10'",  # Python 3.10
     "numpy>=1.26.2,<2  ; python_version < '3.10' and python_version >= '3.9' ",  # Python 3.9
     "numpy>=1.24.4,<2  ; python_version < '3.9'  and python_version >= '3.8' ",  # Python 3.8
@@ -42,7 +43,7 @@ ci_pypi_test_password_varname = 'PYPY_TEST'
 [tool.cibuildwheel]
 # Options for this section are documented here
 # https://cibuildwheel.readthedocs.io/en/stable/options/
-build = "cp38-* cp39-* cp310-* cp311-*"
+build = "cp38-* cp39-* cp310-* cp311-* cp312-*"
 #build = "cp310-manylinux_x86_64"
 build-frontend = "build"
 skip = "*-win32 *-musllinux_* *i686 pp*"
@@ -54,9 +55,12 @@ build-verbosity = 1
 [tool.cibuildwheel.linux]
     archs = ["x86_64"]
     # Use custom manylinux images to get precompiled build-time deps
-    manylinux-x86_64-image = "quay.io/erotemic/manylinux2014_x86_64_for:zlib-build-fortran-gsl"
-    manylinux-i686-image = "quay.io/erotemic/manylinux2014_i686_for:zlib-build-fortran-gsl"
-    # Uncomment to work with official manylinux images  
+    # manylinux-x86_64-image = "quay.io/erotemic/manylinux2014_x86_64_for:zlib-build-fortran-gsl"
+    # manylinux-i686-image = "quay.io/erotemic/manylinux2014_i686_for:zlib-build-fortran-gsl"
+    # Uncomment to work with official manylinux images 
+    # manylinux-x86_64-image = "quay.io/pypa/manylinux2014_x86_64"
+    before-build="yum install gcc-c++ zlib-devel gcc-gfortran libgomp blas-devel -y && curl https://ftp.gnu.org/gnu/gsl/gsl-2.7.1.tar.gz  > gsl.tar.gz && tar xfv gsl.tar.gz && cd gsl-2.7.1 && ./configure --prefix=/usr --disable-static && make && make install"
+    # manylinux-i686-image = "quay.io/erotemic/manylinux2014_i686_for:zlib-build-fortran-gsl"
     #before-build = "yum install gcc gcc-c++ make zlib-devel gcc-gfortran libgomp blas-devel -y && curl https://ftp.gnu.org/gnu/gsl/gsl-2.7.1.tar.gz  > gsl.tar.gz && tar xfv gsl.tar.gz && cd gsl-2.7.1 && ./configure --prefix=/usr --disable-static && make && make install"
     #before-build = "yum install libgomp blas-devel -y"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ ci_pypi_test_password_varname = 'PYPY_TEST'
 [tool.cibuildwheel]
 # Options for this section are documented here
 # https://cibuildwheel.readthedocs.io/en/stable/options/
-build = "cp38-* cp39-* cp310-* cp311-* cp312-*"
+build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
 #build = "cp310-manylinux_x86_64"
 build-frontend = "build"
 skip = "*-win32 *-musllinux_* *i686 pp*"

--- a/requirements/graphics.txt
+++ b/requirements/graphics.txt
@@ -4,7 +4,8 @@
 
 # xdev availpkg opencv-python-headless
 # --prefer-binary
-opencv-python>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python>=4.10.0.84 ; python_version < '4.0'  and python_version >= '3.13'    # Python 3.13+
+opencv-python>=4.5.5.64  ; python_version < '3.13'  and python_version >= '3.11'    # Python 3.11~3.12
 opencv-python>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 opencv-python>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
 opencv-python>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8

--- a/requirements/headless.txt
+++ b/requirements/headless.txt
@@ -5,7 +5,8 @@
 
 # xdev availpkg opencv-python-headless
 # --prefer-binary
-opencv-python-headless>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python-headless>=4.10.0.84  ; python_version < '4.0'  and python_version >= '3.13'    # Python 3.13+
+opencv-python-headless>=4.5.5.64  ; python_version < '3.13'  and python_version >= '3.11'    # Python 3.11~3.12
 opencv-python-headless>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 opencv-python-headless>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
 opencv-python-headless>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,30 +1,36 @@
-numpy>=1.26.2,<2  ; python_version < '4.0'  and python_version >= '3.11'  # Python 3.11+ 
+numpy>=2.1.0      ; python_version < '4.0'  and python_version >= '3.13'  # Python 3.13+
+numpy>=1.26.2,<2  ; python_version < '3.13' and python_version >= '3.11'  # Python 3.11~12
 numpy>=1.26.2,<2  ; python_version < '3.11' and python_version >= '3.10'  # Python 3.10
 numpy>=1.26.2,<2  ; python_version < '3.10' and python_version >= '3.9'   # Python 3.9
 numpy>=1.24.4,<2  ; python_version < '3.9'  and python_version >= '3.8'   # Python 3.8
 
-joblib>=1.1.0
+joblib>=1.2.0
 pyyaml>=6.0.2, <7 ;  python_version < '4.0 '  and python_version >= '3.10'   # Python 3.10+
 pyyaml>=5.4.1, <6 ;  python_version < '3.10'   and python_version >= '3.8'   # Python 3.8~9
 
 fiona>=1.10.1 ,<2 ;  python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
 fiona>=1.10.1 ,<2 ;  python_version < '3.11'
 
-scikit_learn>=1.1.3     ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+scikit_learn>=1.6.0     ; python_version < '4.0'  and python_version >= '3.13'    # Python 3.13+
+scikit_learn>=1.4.0     ; python_version < '3.13' and python_version >= '3.12'    # Python 3.12
+scikit_learn>=1.1.3     ; python_version < '3.12' and python_version >= '3.11'    # Python 3.11
 scikit_learn>=1.1.1     ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 scikit-learn>=0.24.2    ; python_version < '3.10' and python_version >= '3.9'     # Python 3.9
 scikit-learn>=0.24.2    ; python_version < '3.9'  and python_version >= '3.8'     # Python 3.8
 
-scikit_image>=0.20.0  ;  python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+scikit_image>=0.22.0  ;  python_version < '4.0'  and python_version >= '3.12'    # Python 3.12+
+scikit_image>=0.20.0  ;  python_version < '3.12' and python_version >= '3.11'    # Python 3.11
 scikit_image>=0.19.3  ;  python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 scikit_image>=0.18.1  ;  python_version < '3.10'    
 
-pandas>=1.5.0,<2  ; python_version < '4.0'  and python_version >= '3.11'   # Python 3.11+
+pandas>=2.2.3     ; python_version < '4.0'  and python_version >= '3.12'   # Python 3.12+
+pandas>=1.5.0,<2  ; python_version < '3.12' and python_version >= '3.11'   # Python 3.11
 pandas>=1.4.0,<2  ; python_version < '3.11' and python_version >= '3.10'   # Python 3.10
 pandas>=1.4.0,<2  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
 pandas>=1.4.0,<2  ; python_version < '3.9' and python_version >= '3.8'     # Python 3.8
 
-astropy>=5.2.2  ,<6 ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+astropy>=7.0.0      ; python_version < '4.0'  and python_version >= '3.13'    # Python 3.11+
+astropy>=5.3.4  ,<6 ; python_version < '3.13' and python_version >= '3.11'    # Python 3.11~12
 astropy>=5.1    ,<6 ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 astropy>=5.1    ,<6 ; python_version < '3.10' and python_version >= '3.9'     # Python 3.9
 astropy>=5.1    ,<6 ; python_version < '3.9'  and python_version >= '3.8'     # Python 3.8

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,7 @@
 xdoctest>=1.0.2
 ubelt>=1.2.1
 
+setuptools>=76.0 ; python_version >= '3.12' # distutils is removed from 3.12
 # Pin maximum pytest versions for older python versions
 pytest>=6.2.5            ;                               python_version >= '3.10.0'  # Python 3.10+
 pytest>=4.6.0            ; python_version < '3.10.0' and python_version >= '3.7.0'   # Python 3.7-3.9

--- a/src/python/pyxccd/ob_analyst.py
+++ b/src/python/pyxccd/ob_analyst.py
@@ -429,7 +429,7 @@ def segmentation_floodfill(
     )
     mean_list = (
         np.bincount(
-            ids_s1.astype(int), weights=cm_array_gaussian_s1.reshape(ids_s1.shape)
+            ids_s1.flatten().astype(int), weights=cm_array_gaussian_s1.reshape(ids_s1.flatten().shape)
         )
         / count_s1
     )
@@ -743,6 +743,10 @@ def object_analysis(
     unq_s2, ids_s2, count_s2 = np.unique(
         object_map_s2, return_inverse=True, return_counts=True
     )
+    # force ids_s2 to be one-dimensional array, for compatibility with numpy2.x
+    # https://numpy.org/doc/stable/reference/generated/numpy.unique.html
+    ids_s2 = ids_s2.reshape(-1)
+
     lut_dict_s2 = dict(zip(unq_s2, count_s2))
     size_map = np.vectorize(lut_dict_s2.get)(
         object_map_s2


### PR DESCRIPTION
- Updated dependencies
- Switched to official `quay.io/pypa/manylinux2014_x86_64` image for building linux wheels. This image supports CP312 and CP313 but need to install some libraries before every run.
- Fixed compatibility issues introduced from Numpy 1.x to Numpy 2.x (required by CP313)