### PR TITLE
Fix: wrong scm_version detection on windows runner & mismatched wheel during testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/linux_wheels.yml
+++ b/.github/workflows/linux_wheels.yml
@@ -97,6 +97,10 @@ jobs:
       with:
         name: wheels-${{ matrix.cibw-only }}
         path: wheelhouse
+
+    - name: Display structure of downloaded files
+      run: ls -R wheelhouse
+
     - name: Install wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: bash
       env:

--- a/.github/workflows/linux_wheels.yml
+++ b/.github/workflows/linux_wheels.yml
@@ -6,6 +6,10 @@ on:
   #   branches: [ devel, main ]
   # tags: [ '*' ]
   workflow_call:
+    inputs:
+      scm_version:
+        type: string
+        required: true
   workflow_dispatch:
 
 jobs:
@@ -87,7 +91,9 @@ jobs:
         platforms: all
     - name: Extract python version from cibw-only
       id: extract-python-version
-      run: echo python-version=$(echo "${{ matrix.cibw-only }}" | sed -n 's/^cp\([0-9]\)\([0-9]\{1,2\}\).*/\1.\2/p' ) >> $GITHUB_OUTPUT
+      run: |
+        echo cp-version=$(echo "${{ matrix.cibw-only }}" | sed -En 's/^(cp[0-9]{2,3}).*/\1/p') >> $GITHUB_OUTPUT
+        echo python-version=$(echo "${{ matrix.cibw-only }}" | sed -n 's/^cp\([0-9]\)\([0-9]\{1,2\}\).*/\1.\2/p' ) >> $GITHUB_OUTPUT
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
@@ -98,14 +104,19 @@ jobs:
         name: wheels-${{ matrix.cibw-only }}
         path: wheelhouse
 
-    - name: Display structure of downloaded files
-      run: ls -R wheelhouse
+    - name: Display structure of downloaded files, output unique filename
+      id: show-wheel-files
+      run: |
+        ls -R wheelhouse
+        WHEEL_FPATH=$(ls wheelhouse/pyxccd-${{inputs.scm_version}}-${{steps.extract-python-version.outputs.cp-version}}*.whl) 
+        echo "wheel_fpath=$WHEEL_FPATH"
+        echo wheel_fpath="$WHEEL_FPATH" >> $GITHUB_OUTPUT
 
     - name: Install wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: bash
       env:
         INSTALL_EXTRAS: ${{ matrix.install-extras }}
-      run: pip install --prefer-binary "pyxccd[$INSTALL_EXTRAS]" -f wheelhouse # there should be only one wheel in the wheelhouse directory
+      run: pip install --prefer-binary "${{ steps.show-wheel-files.outputs.wheel_fpath }}[$INSTALL_EXTRAS]" -f wheelhouse # there should be only one wheel in the wheelhouse directory
 
     - name: Test wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
         SCM_VERSION=$(python -m setuptools_scm)
         echo "scm_version=$SCM_VERSION"
         echo scm_version=$SCM_VERSION >> $GITHUB_OUTPUT
-
+      env:
+        SETUPTOOLS_SCM_DEBUG: "1"
     - name: Lint with flake8
       run: |-
         # stop the build if there are Python syntax errors or undefined names
@@ -128,6 +129,16 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
+    - name: ensure no "dev" in scm_version
+      if: contains(needs.lint_job.outputs.scm_version, 'dev')
+      run: |
+        echo "Error: scm_version=${{ needs.lint_job.outputs.scm_version }} is a 'dev' version. This is not allowed for a release tag."
+        exit 1
+    - name: ensure scm_version match the tag name
+      if: needs.lint_job.outputs.scm_version !=  github.ref_name
+      run: |
+        echo "Error: scm_version=${{ needs.lint_job.outputs.scm_version }} does not match the tag name ${{ github.ref_name }}."
+        exit 1
     - uses: actions/download-artifact@v4
       with:
         pattern: wheels-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,14 @@ jobs:
     # To disable type checks add "notypes" to the xcookie tags.
     ##
     runs-on: ubuntu-latest
+    outputs:
+      scm_version: ${{ steps.version.outputs.scm_version }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch all history for accurate version calculation
+
     - name: Set up Python 3.11 for linting
       uses: actions/setup-python@v5
       with:
@@ -41,7 +46,15 @@ jobs:
     - name: Install dependencies
       run: |-
         python -m pip install --upgrade pip
-        python -m pip install flake8
+        python -m pip install flake8 setuptools_scm
+
+    - name: Get version with setuptools_scm
+      id: version
+      run: |
+        SCM_VERSION=$(python -m setuptools_scm)
+        echo "scm_version=$SCM_VERSION"
+        echo scm_version=$SCM_VERSION >> $GITHUB_OUTPUT
+
     - name: Lint with flake8
       run: |-
         # stop the build if there are Python syntax errors or undefined names
@@ -55,17 +68,26 @@ jobs:
   build_and_test_sdist:
     needs: lint_job # run linting before building and testing
     uses: ./.github/workflows/sdist_tests.yml
+    with:
+      scm_version: ${{ needs.lint_job.outputs.scm_version }}
   build_and_test_linux_wheels:
+    needs: lint_job # run linting before building and testing
     if: github.event_name == 'push' && (github.event.ref =='refs/heads/master' || github.event.ref =='refs/heads/devel' || startsWith(github.event.ref, 'refs/tags')) 
     uses: ./.github/workflows/linux_wheels.yml
+    with:
+      scm_version: ${{ needs.lint_job.outputs.scm_version }}
   
   build_and_test_windows_wheels:
+    needs: lint_job # run linting before building and testing
     if: github.event_name == 'push' && (github.event.ref =='refs/heads/master' || github.event.ref =='refs/heads/devel' || startsWith(github.event.ref, 'refs/tags')) 
     uses: ./.github/workflows/win_wheels.yml
+    with:
+      scm_version: ${{ needs.lint_job.outputs.scm_version }}
 
   # job to upload the package to PyPI
   upload-to-test-pypi:
     needs: 
+      - lint_job
       - build_and_test_sdist
       - build_and_test_linux_wheels
       - build_and_test_windows_wheels
@@ -85,6 +107,7 @@ jobs:
     - name: Show files to upload
       shell: bash
       run: ls -la dist
+
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -93,6 +116,7 @@ jobs:
         verbose: true
   upload-to-pypi:
     needs: 
+      - lint_job
       - build_and_test_sdist
       - build_and_test_linux_wheels
       - build_and_test_windows_wheels

--- a/.github/workflows/sdist_tests.yml
+++ b/.github/workflows/sdist_tests.yml
@@ -6,6 +6,10 @@ on:
   #   branches: [ devel, main ]
   # tags: [ '*' ]
   workflow_call:
+    inputs:
+      scm_version:
+        type: string
+        required: true
   workflow_dispatch:
 
 jobs:
@@ -47,7 +51,7 @@ jobs:
     - name: Install sdist
       run: |-
         ls -al ./wheelhouse
-        pip install --prefer-binary wheelhouse/pyxccd*.tar.gz -v
+        pip install --prefer-binary wheelhouse/pyxccd-${{ inputs.scm_version }}.tar.gz -v
     - name: Test minimal loose sdist
       run: |-
         pwd

--- a/.github/workflows/win_wheels.yml
+++ b/.github/workflows/win_wheels.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    # - run: git config --global core.autocrlf input # https://github.com/msys2/setup-msys2/tree/v2/?tab=readme-ov-file#known-problems avoid dirty repo
+    #   shell: cmd
     - name: Checkout source
       uses: actions/checkout@v4
       with:
@@ -50,7 +52,12 @@ jobs:
 
     - name: install cibuildwheel # cannot use pypa/cibuildwheel because we need to use msys2
       run: |
-        ${{ steps.replace-path.outputs.py_path }} -m pip install cibuildwheel
+        ${{ steps.replace-path.outputs.py_path }} -m pip install cibuildwheel setuptools_scm
+    
+    - name: check git status
+      run: |
+        git status
+        ${{ steps.replace-path.outputs.py_path }} -m setuptools_scm
 
     - name: Build binary wheels
       run: |
@@ -106,6 +113,10 @@ jobs:
       with:
         name: wheels-${{ matrix.cibw-only }}
         path: wheelhouse
+
+    - name: Display structure of downloaded files
+      run: ls -R wheelhouse
+
     - name: Install wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: powershell
       env:

--- a/.github/workflows/win_wheels.yml
+++ b/.github/workflows/win_wheels.yml
@@ -2,6 +2,10 @@ name: Build Winows Wheels
 
 on:
   workflow_call:
+    inputs:
+      scm_version:
+        type: string
+        required: true
   workflow_dispatch:
 
 jobs:
@@ -102,7 +106,9 @@ jobs:
     - name: Extract python version from cibw-only
       id: extract-python-version
       shell: bash
-      run: echo python-version=$(echo "${{ matrix.cibw-only }}" | sed -n 's/^cp\([0-9]\)\([0-9]\{1,2\}\).*/\1.\2/p' ) >> $GITHUB_OUTPUT
+      run: |
+        echo cp-version=$(echo "${{ matrix.cibw-only }}" | sed -En 's/^(cp[0-9]{2,3}).*/\1/p') >> $GITHUB_OUTPUT
+        echo python-version=$(echo "${{ matrix.cibw-only }}" | sed -n 's/^cp\([0-9]\)\([0-9]\{1,2\}\).*/\1.\2/p' ) >> $GITHUB_OUTPUT
 
     - name: Setup Python
       uses: actions/setup-python@v5
@@ -114,14 +120,20 @@ jobs:
         name: wheels-${{ matrix.cibw-only }}
         path: wheelhouse
 
-    - name: Display structure of downloaded files
-      run: ls -R wheelhouse
+    - name: Display structure of downloaded files, output unique filename
+      id: show-wheel-files
+      shell: bash
+      run: |
+        ls -R wheelhouse
+        WHEEL_FPATH=$(ls wheelhouse/pyxccd-${{inputs.scm_version}}-${{steps.extract-python-version.outputs.cp-version}}*.whl) 
+        echo "wheel_fpath=$WHEEL_FPATH"
+        echo wheel_fpath="$WHEEL_FPATH" >> $GITHUB_OUTPUT
 
     - name: Install wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: powershell
       env:
         INSTALL_EXTRAS: ${{ matrix.install-extras }}
-      run: pip install --prefer-binary "pyxccd[$($env:INSTALL_EXTRAS)]" -f wheelhouse # there should be only one wheel in the wheelhouse directory
+      run: pip install --prefer-binary "${{ steps.show-wheel-files.outputs.wheel_fpath }}[$($env:INSTALL_EXTRAS)]" -f wheelhouse # there should be only one wheel in the wheelhouse directory
 
     - name: Test wheel ${{ matrix.cibw-only }} with extras ${{ matrix.install-extras }}
       shell: powershell


### PR DESCRIPTION
- Added a `.gitattributes` file to disable `autocrlf` conversion on Windows, so that setuptools_scm won't mark the repo as dirty
- Added strict version check when installing wheel file during tests, so that pip won't download the wrong version from PyPI.
- Added final release version check before uploading to PyPI